### PR TITLE
inform libutp when read buffer has been drained

### DIFF
--- a/utpgo.go
+++ b/utpgo.go
@@ -70,7 +70,7 @@ type Conn struct {
 	// not yet consumed by the application.
 	readBuffer *buffers.SyncCircularBuffer
 
-	// writeBuffer tracks data that needs to be sent on this Conn, which is
+	// writeBuffer tracks data that needs to be sent on this Conn, which
 	// has not yet been collected by µTP.
 	writeBuffer *buffers.SyncCircularBuffer
 
@@ -421,6 +421,7 @@ func (c *Conn) ReadContext(ctx context.Context, buf []byte) (n int, err error) {
 			if n == 0 {
 				return 0, io.EOF
 			}
+			c.baseConn.RBDrained()
 			return n, nil
 		}
 		if encounteredErr != nil {


### PR DESCRIPTION
We were having stalls occur whenever the read buffer filled up entirely, because data could not be consumed as fast as it was arriving on the network. This occurred because we were not calling a particular libutp method which is supposed to let that layer know that more space has opened up in the read buffer. Since we were not calling it, the system kept assuming that the read buffer was full forever, and never sent a further ACK updating the remote side that the window was more open.

Now, any time we consume data from the read buffer, we will call RBDrained() on the baseConn.