### PR TITLE
hold baseConnLock while calling RBDrained

### DIFF
--- a/utpgo.go
+++ b/utpgo.go
@@ -459,7 +459,9 @@ func (c *Conn) ReadContext(ctx context.Context, buf []byte) (n int, err error) {
 			if n == 0 {
 				return 0, io.EOF
 			}
+			c.manager.baseConnLock.Lock()
 			c.baseConn.RBDrained()
+			c.manager.baseConnLock.Unlock()
 			return n, nil
 		}
 		if encounteredErr != nil {


### PR DESCRIPTION
Overlooked the need for this when adding the RBDrained call.