### PR TITLE
replace logr with zap entirely

### DIFF
--- a/libutp/transfer_test.go
+++ b/libutp/transfer_test.go
@@ -15,7 +15,6 @@ import (
 	"testing"
 	"time"
 
-	"github.com/go-logr/zapr"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 	"go.uber.org/zap/zaptest"
@@ -188,7 +187,7 @@ type testScenario struct {
 }
 
 func newTestScenario(t testing.TB) *testScenario {
-	logger := zapr.NewLogger(zaptest.NewLogger(t))
+	logger := zaptest.NewLogger(t)
 	scenario := &testScenario{}
 	scenario.mx = NewSocketMultiplexer(logger, scenario.getTime)
 

--- a/libutp/utp_file/utp_recv/utp_recv.go
+++ b/libutp/utp_file/utp_recv/utp_recv.go
@@ -14,7 +14,6 @@ import (
 	"os"
 	"time"
 
-	"github.com/go-logr/zapr"
 	"go.uber.org/zap"
 	"go.uber.org/zap/zapcore"
 
@@ -121,7 +120,7 @@ func newFileStreamReceiver(logger *zap.Logger, listenAddr string, fileDest io.Wr
 		err = fmt.Errorf("could not listen on %q: %w", listenAddr, err)
 		return nil, err
 	}
-	sm := utp_file.NewUDPSocketManager(zapr.NewLogger(logger))
+	sm := utp_file.NewUDPSocketManager(logger)
 	sm.SetSocket(sock)
 
 	fsr := &fileStreamReceiver{

--- a/libutp/utp_file/utp_send/utp_send.go
+++ b/libutp/utp_file/utp_send/utp_send.go
@@ -15,7 +15,6 @@ import (
 	"syscall"
 	"time"
 
-	"github.com/go-logr/zapr"
 	"go.uber.org/zap"
 	"go.uber.org/zap/zapcore"
 
@@ -79,7 +78,7 @@ func main() {
 		logger.Fatal("file is 0 bytes")
 	}
 
-	sm := utp_file.NewUDPSocketManager(zapr.NewLogger(logger))
+	sm := utp_file.NewUDPSocketManager(logger)
 
 	udpSock, err := utp_file.MakeSocket(":0")
 	if err != nil {

--- a/tls_test.go
+++ b/tls_test.go
@@ -12,7 +12,6 @@ import (
 	"testing"
 	"time"
 
-	"github.com/go-logr/zapr"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 	"go.uber.org/zap"
@@ -83,12 +82,11 @@ func TestTLSOverUTPInParallel(t *testing.T) {
 	addrChan := make(chan *utp.Addr, 1)
 
 	logger := zaptest.NewLogger(t, zaptest.Level(zapcore.Level(logLevel)))
-	compatibleLogger := zapr.NewLogger(logger)
 
 	group := newLabeledErrgroup(context.Background())
 
 	group.Go(func(ctx context.Context) (err error) {
-		server, err := utp.ListenTLSOptions("utp", "127.0.0.1:0", &serverConfig, utp.WithLogger(compatibleLogger))
+		server, err := utp.ListenTLSOptions("utp", "127.0.0.1:0", &serverConfig, utp.WithLogger(logger))
 		if err != nil {
 			logger.Error("could not listen", zap.Error(err))
 			return err
@@ -117,7 +115,7 @@ func TestTLSOverUTPInParallel(t *testing.T) {
 	addr := <-addrChan
 	for i := 0; i < tlsTestRepeats; i++ {
 		group.Go(func(ctx context.Context) (err error) {
-			client, err := utp.DialTLSOptions(addr.Network(), addr.String(), &clientConfig, utp.WithLogger(compatibleLogger))
+			client, err := utp.DialTLSOptions(addr.Network(), addr.String(), &clientConfig, utp.WithLogger(logger))
 			if err != nil {
 				return err
 			}

--- a/utpgo.go
+++ b/utpgo.go
@@ -17,7 +17,7 @@ import (
 	"syscall"
 	"time"
 
-	"github.com/go-logr/logr"
+	"go.uber.org/zap"
 
 	"storj.io/utp-go/buffers"
 	"storj.io/utp-go/libutp"
@@ -30,7 +30,7 @@ const (
 	writeBufferSize = 200000
 )
 
-var noopLogger = logr.Discard()
+var noopLogger = zap.NewNop()
 
 // Addr represents a µTP address.
 type Addr net.UDPAddr
@@ -45,7 +45,7 @@ func (a *Addr) String() string { return (*net.UDPAddr)(a).String() }
 type Conn struct {
 	utpSocket
 
-	logger logr.Logger
+	logger *zap.Logger
 
 	baseConn *libutp.Socket
 
@@ -170,8 +170,8 @@ func DialUTPOptions(network string, localAddr, remoteAddr *Addr, options ...Conn
 	return conn, nil
 }
 
-func dial(ctx context.Context, logger logr.Logger, network string, localAddr, remoteAddr *Addr) (*Conn, error) {
-	managerLogger := logger.WithValues("remote-addr", remoteAddr.String())
+func dial(ctx context.Context, logger *zap.Logger, network string, localAddr, remoteAddr *Addr) (*Conn, error) {
+	managerLogger := logger.With(zap.Stringer("remote-addr", remoteAddr))
 	manager, err := newSocketManager(managerLogger, network, (*net.UDPAddr)(localAddr), (*net.UDPAddr)(remoteAddr))
 	if err != nil {
 		return nil, err
@@ -179,14 +179,14 @@ func dial(ctx context.Context, logger logr.Logger, network string, localAddr, re
 	localUDPAddr := manager.LocalAddr().(*net.UDPAddr)
 	// different from managerLogger in case local addr interface and/or port
 	// has been clarified
-	connLogger := logger.WithValues("local-addr", localUDPAddr.String(), "remote-addr", remoteAddr.String(), "dir", "out")
+	connLogger := logger.With(zap.Stringer("local-addr", localUDPAddr), zap.Stringer("remote-addr", remoteAddr), zap.String("dir", "out"))
 
 	utpConn := &Conn{
 		utpSocket: utpSocket{
 			localAddr: localUDPAddr,
 			manager:   manager,
 		},
-		logger:            connLogger.WithName("utp-conn"),
+		logger:            connLogger.Named("utp-conn"),
 		connecting:        true,
 		connectChan:       make(chan struct{}),
 		closeChan:         make(chan struct{}),
@@ -194,7 +194,7 @@ func dial(ctx context.Context, logger logr.Logger, network string, localAddr, re
 		readBuffer:        buffers.NewSyncBuffer(readBufferSize),
 		writeBuffer:       buffers.NewSyncBuffer(writeBufferSize),
 	}
-	connLogger.V(10).Info("creating outgoing socket")
+	connLogger.Debug("creating outgoing socket")
 	// thread-safe here, because no other goroutines could have a handle to
 	// this mx yet.
 	utpConn.baseConn, err = manager.mx.Create(packetSendCallback, manager, (*net.UDPAddr)(remoteAddr))
@@ -208,7 +208,7 @@ func dial(ctx context.Context, logger logr.Logger, network string, localAddr, re
 		OnState:   onStateCallback,
 		OnError:   onErrorCallback,
 	}, utpConn)
-	utpConn.baseConn.SetLogger(connLogger.WithName("utp-socket"))
+	utpConn.baseConn.SetLogger(connLogger.Named("utp-socket"))
 	utpConn.baseConn.SetSockOpt(syscall.SO_RCVBUF, readBufferSize)
 
 	manager.start()
@@ -218,7 +218,7 @@ func dial(ctx context.Context, logger logr.Logger, network string, localAddr, re
 		// concurrency protection
 		manager.baseConnLock.Lock()
 		defer manager.baseConnLock.Unlock()
-		connLogger.V(10).Info("initiating libutp-level Connect()")
+		connLogger.Debug("initiating libutp-level Connect()")
 		utpConn.baseConn.Connect()
 	}()
 
@@ -292,7 +292,7 @@ func ListenUTPOptions(network string, localAddr *Addr, options ...ConnectOption)
 	return listen(s.logger, network, localAddr)
 }
 
-func listen(logger logr.Logger, network string, localAddr *Addr) (*Listener, error) {
+func listen(logger *zap.Logger, network string, localAddr *Addr) (*Listener, error) {
 	manager, err := newSocketManager(logger, network, (*net.UDPAddr)(localAddr), nil)
 	if err != nil {
 		return nil, err
@@ -310,7 +310,7 @@ func listen(logger logr.Logger, network string, localAddr *Addr) (*Listener, err
 }
 
 type utpDialState struct {
-	logger    logr.Logger
+	logger    *zap.Logger
 	ctx       context.Context
 	tlsConfig *tls.Config
 }
@@ -321,7 +321,7 @@ type ConnectOption interface {
 }
 
 type optionLogger struct {
-	logger logr.Logger
+	logger *zap.Logger
 }
 
 func (o *optionLogger) apply(s *utpDialState) {
@@ -331,7 +331,7 @@ func (o *optionLogger) apply(s *utpDialState) {
 // WithLogger creates a connection option which specifies a logger to be
 // attached to the connection. The logger will receive debugging messages
 // about the socket.
-func WithLogger(logger logr.Logger) ConnectOption {
+func WithLogger(logger *zap.Logger) ConnectOption {
 	return &optionLogger{logger: logger}
 }
 
@@ -388,7 +388,7 @@ func (c *Conn) Close() error {
 		// it may end up invoking callbacks
 		c.manager.baseConnLock.Lock()
 		defer c.manager.baseConnLock.Unlock()
-		c.logger.V(10).Info("closing baseConn")
+		c.logger.Debug("closing baseConn")
 		c.libutpClosed = true
 		return c.baseConn.Close()
 	}()
@@ -408,7 +408,7 @@ func (c *Conn) Close() error {
 
 // SetLogger sets the logger to be used by a connection. The logger will receive
 // debugging information about the socket.
-func (c *Conn) SetLogger(logger logr.Logger) {
+func (c *Conn) SetLogger(logger *zap.Logger) {
 	c.baseConn.SetLogger(logger)
 }
 
@@ -556,7 +556,7 @@ func (c *Conn) WriteContext(ctx context.Context, buf []byte) (n int, err error) 
 				defer c.manager.baseConnLock.Unlock()
 
 				amount := c.writeBuffer.SpaceUsed()
-				c.logger.V(10).Info("informing libutp layer of data for writing", "len", amount)
+				c.logger.Debug("informing libutp layer of data for writing", zap.Int("len", amount))
 				c.baseConn.Write(amount)
 			}()
 
@@ -718,7 +718,7 @@ func (u *utpSocket) LocalAddr() net.Addr {
 
 type socketManager struct {
 	mx        *libutp.SocketMultiplexer
-	logger    logr.Logger
+	logger    *zap.Logger
 	udpSocket *net.UDPConn
 
 	// this lock should be held when invoking any libutp functions or methods
@@ -756,7 +756,7 @@ const (
 	defaultUTPConnBacklogSize = 5
 )
 
-func newSocketManager(logger logr.Logger, network string, localAddr, remoteAddr *net.UDPAddr) (*socketManager, error) {
+func newSocketManager(logger *zap.Logger, network string, localAddr, remoteAddr *net.UDPAddr) (*socketManager, error) {
 	switch network {
 	case "utp", "utp4", "utp6":
 	default:
@@ -774,11 +774,11 @@ func newSocketManager(logger logr.Logger, network string, localAddr, remoteAddr 
 	}
 
 	// thread-safe here; don't need baseConnLock
-	mx := libutp.NewSocketMultiplexer(logger.WithName("mx").WithValues("local-addr", udpSocket.LocalAddr().String()), nil)
+	mx := libutp.NewSocketMultiplexer(logger.Named("mx").With(zap.Stringer("local-addr", udpSocket.LocalAddr())), nil)
 
 	sm := &socketManager{
 		mx:           mx,
-		logger:       logger.WithName("manager").WithValues("local-addr", udpSocket.LocalAddr().String()),
+		logger:       logger.Named("manager").With(zap.Stringer("local-addr", udpSocket.LocalAddr())),
 		udpSocket:    udpSocket,
 		refCount:     1,
 		closeErr:     make(chan error),
@@ -856,7 +856,7 @@ func (sm *socketManager) decrementReferences() error {
 	defer sm.refCountLock.Unlock()
 	sm.refCount--
 	if sm.refCount == 0 {
-		sm.logger.V(1).Info("closing socketManager")
+		sm.logger.Info("closing socketManager")
 		sm.cancelManagement()
 		return <-sm.closeErr
 	}
@@ -875,7 +875,7 @@ func (sm *socketManager) udpMessageReceiver(ctx context.Context) {
 	// receive buffer twice as big as we thought we might need, and increase it
 	// further from there if needed.
 	bufSize *= 2
-	sm.logger.V(0).Info("udp message receiver started", "receive-buf-size", bufSize)
+	sm.logger.Info("udp message receiver started", zap.Uint16("receive-buf-size", bufSize))
 	b := make([]byte, bufSize)
 	for {
 		n, _, flags, addr, err := sm.udpSocket.ReadMsgUDP(b, nil)
@@ -894,7 +894,7 @@ func (sm *socketManager) udpMessageReceiver(ctx context.Context) {
 			// do its part instead.
 			continue
 		}
-		sm.logger.V(10).Info("udp received bytes", "len", n)
+		sm.logger.Debug("udp received bytes", zap.Int("len", n))
 		sm.processIncomingPacket(b[:n], addr)
 	}
 }
@@ -902,7 +902,7 @@ func (sm *socketManager) udpMessageReceiver(ctx context.Context) {
 func (sm *socketManager) registerSocketError(err error) {
 	sm.socketErrorsLock.Lock()
 	defer sm.socketErrorsLock.Unlock()
-	sm.logger.Error(err, "socket error")
+	sm.logger.Error("socket error", zap.Error(err))
 	sm.socketErrors = append(sm.socketErrors, err)
 }
 
@@ -916,7 +916,7 @@ func gotIncomingConnectionCallback(userdata interface{}, newBaseConn *libutp.Soc
 	}
 	sm.incrementReferences()
 
-	connLogger := sm.logger.WithName("utp-socket").WithValues("dir", "in", "remote-addr", newBaseConn.GetPeerName().String())
+	connLogger := sm.logger.Named("utp-socket").With(zap.String("dir", "in"), zap.Stringer("remote-addr", newBaseConn.GetPeerName()))
 	newUTPConn := &Conn{
 		utpSocket: utpSocket{
 			localAddr: sm.LocalAddr().(*net.UDPAddr),
@@ -936,13 +936,13 @@ func gotIncomingConnectionCallback(userdata interface{}, newBaseConn *libutp.Soc
 		OnState:   onStateCallback,
 		OnError:   onErrorCallback,
 	}, newUTPConn)
-	sm.logger.V(1).Info("accepted new connection", "remote-addr", newUTPConn.RemoteAddr().String())
+	sm.logger.Info("accepted new connection", zap.Stringer("remote-addr", newUTPConn.RemoteAddr()))
 	newUTPConn.baseConn.SetSockOpt(syscall.SO_RCVBUF, readBufferSize)
 	select {
 	case sm.acceptChan <- newUTPConn:
 		// it's the socketManager's problem now
 	default:
-		sm.logger.Info("dropping new connection because full backlog", "remote-addr", newUTPConn.RemoteAddr())
+		sm.logger.Info("dropping new connection because full backlog", zap.Stringer("remote-addr", newUTPConn.RemoteAddr()))
 		// The accept backlog is full; drop this new connection. We can't call
 		// (*Conn).Close() from here, because the baseConnLock is already held.
 		// Fortunately, most of the steps done there aren't necessary here
@@ -957,7 +957,7 @@ func gotIncomingConnectionCallback(userdata interface{}, newBaseConn *libutp.Soc
 
 func packetSendCallback(userdata interface{}, buf []byte, addr *net.UDPAddr) {
 	sm := userdata.(*socketManager)
-	sm.logger.V(10).Info("udp sending bytes", "len", len(buf))
+	sm.logger.Debug("udp sending bytes", zap.Int("len", len(buf)))
 	_, err := sm.udpSocket.WriteToUDP(buf, addr)
 	if err != nil {
 		sm.registerSocketError(err)
@@ -981,7 +981,7 @@ func onReadCallback(userdata interface{}, buf []byte) {
 		// keep us from getting more data than the receive buffer can hold.
 		used := c.readBuffer.SpaceUsed()
 		avail := c.readBuffer.SpaceAvailable()
-		c.logger.Error(nil, "receive buffer overflow", "buffer-size", used+avail, "buffer-holds", c.readBuffer.SpaceUsed(), "new-data", len(buf))
+		c.logger.Error("receive buffer overflow", zap.Int("buffer-size", used+avail), zap.Int("buffer-holds", c.readBuffer.SpaceUsed()), zap.Int("new-data", len(buf)))
 		panic("receive buffer overflow")
 	}
 	c.stateDebugLog("finishing onReadCallback")
@@ -1021,10 +1021,10 @@ func (c *Conn) onConnectOrWritable(state libutp.State) {
 	c.stateLock.Unlock()
 
 	if writeAmount := c.writeBuffer.SpaceUsed(); writeAmount > 0 {
-		c.logger.V(10).Info("initiating write to libutp layer", "len", writeAmount)
+		c.logger.Debug("initiating write to libutp layer", zap.Int("len", writeAmount))
 		c.baseConn.Write(writeAmount)
 	} else {
-		c.logger.V(10).Info("nothing to write")
+		c.logger.Debug("nothing to write")
 	}
 
 	c.stateDebugLog("finishing onConnectOrWritable")
@@ -1064,7 +1064,7 @@ func onStateCallback(userdata interface{}, state libutp.State) {
 // the baseConnLock should already be held when this callback is entered.
 func onErrorCallback(userdata interface{}, err error) {
 	c := userdata.(*Conn)
-	c.logger.Error(err, "onError callback from libutp layer")
+	c.logger.Error("onError callback from libutp layer", zap.Error(err))
 
 	// we have to treat this like a total connection failure
 	c.onConnectionFailure(err)
@@ -1074,7 +1074,7 @@ func onErrorCallback(userdata interface{}, err error) {
 	// forever and never get to StateDestroying, so we have to prod it again.
 	if c.libutpClosed {
 		if err := c.baseConn.Close(); err != nil {
-			c.logger.Error(err, "error from libutp layer Close()")
+			c.logger.Error("error from libutp layer Close()", zap.Error(err))
 		}
 	}
 }


### PR DESCRIPTION
I thought logr would be a good way to avoid depending on a single particular logging framework. But it has been too klunky to use, due to its lowest-common-denominator approach, and it is inefficient, showing up too prominently in profiling data.

Zap is optimized for speed, especially in the case where logging is disabled, and in the worst case, it's possible to make a zap log handler that passes info on to a different log framework, such as logrus.

I also took this opportunity to convert the printf-style debug statements inherited from the C++ library into zap-style log statements.

I'm hoping the change in performance characteristics might be enough to make it easier to reproduce the flow control problem we've been seeing.