### PR TITLE
make receive buffer larger than advertised

### DIFF
--- a/libutp/utp.go
+++ b/libutp/utp.go
@@ -2408,9 +2408,9 @@ func (mx *SocketMultiplexer) processIncoming(conn *Socket, packet []byte, syn bo
 		conn.maxWindowUser = p.getWindowSize()
 
 		// If max user window is set to 0, then we startup a timer
-		// That will reset it to 1 after 15 seconds.
+		// That will reset it to packetSize after 15 seconds.
 		if conn.maxWindowUser == 0 {
-			// Reset maxWindowUser to 1 every 15 seconds.
+			// Reset maxWindowUser to packetSize every 15 seconds.
 			conn.zeroWindowTime = currentMS + 15000
 		}
 


### PR DESCRIPTION
After looking carefully through the libutp code, I've verified that we _should_ expect to receive more data than the receive buffer said it could hold, even with a well-behaved peer, and that we can't easily drop such excess packets to make them be transmitted again. Such excess data should be infrequent (e.g., when the receive window has been 0 for >15 seconds, allow one extra packet) so doubling the actual buffer size should make it less likely to have real overflows in normal conditions.

Of course, an overflow is still _possible_, especially with a malicious peer, so for now we will return an error and shut down the connection.